### PR TITLE
Style options page

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		"redux": "^4.0.5",
 		"redux-logger": "^3.0.6",
 		"redux-thunk": "^2.3.0",
+		"webext-base-css": "^1.1.0",
 		"webext-options-sync": "^1.2.3",
 		"webextension-polyfill-ts": "^0.14.0"
 	},

--- a/src/options/index.css
+++ b/src/options/index.css
@@ -1,0 +1,9 @@
+/* Some spacing above the form is necessary in Firefox */
+form {
+	margin-top: 20px;
+}
+
+/* Spacing between label and input */
+input {
+	margin-left: 5px !important; /* stylelint-disable-line declaration-no-important */
+}

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -4,14 +4,19 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+
 		<title>QuickStart Options</title>
+
+		<link rel="stylesheet" href="chrome://global/skin/in-content/common.css" />
+		<link rel="stylesheet" href="webext-base.css" />
+		<link rel="stylesheet" href="options.css" />
 	</head>
 
 	<body>
 		<form>
 			<label>
 				Show clock:
-				<input type="checkbox" name="showClock" required />
+				<input type="checkbox" name="showClock" />
 			</label>
 		</form>
 

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -77,9 +77,16 @@ export default (
 			title: EXT_NAME,
 		}),
 		new CopyPlugin([
+			// Extension manifest
 			"./manifest.json",
+
+			// Extension icons
 			{ from: "./icons/", to: "./icons/" },
-			{ from: "./src/options/index.html", to: "./options.html" }, // Options HTML page
+
+			// Options page
+			{ from: "./src/options/index.html", to: "./options.html" },
+			{ from: "./src/options/index.css", to: "./options.css" },
+			{ from: "./node_modules/webext-base-css/webext-base.css", to: "./webext-base.css" },
 		]) as Plugin,
 	],
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -11415,6 +11415,11 @@ web-ext@^4.1.0:
     yargs "15.1.0"
     zip-dir "1.0.2"
 
+webext-base-css@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/webext-base-css/-/webext-base-css-1.1.0.tgz#bc641d7246c593ec5832879305cb7b196e4a9f22"
+  integrity sha512-idimmVKsaf9ACwbSDnVjE0kFngu0e36yqbmUWEj4sqFd+g1DLkuvYKQcB7e/i73JFE9EOv8apICE7jqC7oWmHA==
+
 webext-detect-page@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/webext-detect-page/-/webext-detect-page-2.0.4.tgz#ecdb421ffced49de2d86a29f8cea61963e62caea"


### PR DESCRIPTION
This PR makes the options page look consistent with the browser UI (using [`webext-base-css`](https://github.com/fregante/webext-base-css)).

**Before (Chrome):**

<img width="1312" alt="chrome-before" src="https://user-images.githubusercontent.com/22477950/79119611-0cff2880-7d91-11ea-82c8-2344bc9eba3b.png">

**After (Chrome):**

<img width="1312" alt="chrome-after" src="https://user-images.githubusercontent.com/22477950/79119630-17b9bd80-7d91-11ea-8f91-e5f395a4966d.png">

**Before (Firefox):**

<img width="1392" alt="firefox-before" src="https://user-images.githubusercontent.com/22477950/79119644-1ee0cb80-7d91-11ea-94d5-3d010a71767f.png">

**After (Firefox):**

<img width="1392" alt="firefox-after" src="https://user-images.githubusercontent.com/22477950/79119652-243e1600-7d91-11ea-9102-3dfd008f5794.png">
