### PR TITLE
Fix modal position

### DIFF
--- a/src/content/components/elements/Modal.module.scss
+++ b/src/content/components/elements/Modal.module.scss
@@ -1,5 +1,5 @@
 .modalOuterWrapper {
-	position: absolute;
+	position: fixed;
 	top: 0;
 	left: 0;
 	z-index: 10000;


### PR DESCRIPTION
Fixes the `Modal` component's position when the user has scrolled.

**Before:**

<img width="947" alt="modal-before" src="https://user-images.githubusercontent.com/22477950/79121671-1e96ff00-7d96-11ea-981d-dababff8ab64.png">

**After:**

<img width="947" alt="modal-after" src="https://user-images.githubusercontent.com/22477950/79121677-2191ef80-7d96-11ea-86a4-e2eedf0e1782.png">
